### PR TITLE
Port to 4.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2016 Franco Eusébio Garcia
+Copyright (C) 2016-2023 Franco Eusébio Garcia
 
 This software is provided 'as-is', without any express or implied warranty.
 

--- a/gdpdf.h
+++ b/gdpdf.h
@@ -3,15 +3,15 @@
 #ifndef GD_PDF_H
 #define GD_PDF_H
 
-#include "core/map.h"
-#include "core/reference.h"
-#include "core/ustring.h"
+#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
+#include "core/templates/vmap.h"
 
 // HARU PDF library.
 #include "libharu/include/hpdf.h"
 
-class PDF : public Reference {
-	GDCLASS(PDF, Reference);
+class PDF : public RefCounted {
+	GDCLASS(PDF, RefCounted);
 
 	HPDF_Doc m_PDF;
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,15 +1,24 @@
 /* register_types.cpp */
 
 #include "register_types.h"
-#include "core/class_db.h"
+
+#include "core/object/class_db.h"
 
 #include "gdpdf.h"
 
-void register_gdpdf_types() {
+void initialize_gdpdf_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
 
-        ClassDB::register_class<PDF>();
+	GDREGISTER_CLASS(PDF);
+	// ClassDB::register_class<PDF>();
 }
 
-void unregister_gdpdf_types() {
-   //nothing to do here
+void uninitialize_gdpdf_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+
+	//nothing to do here
 }

--- a/register_types.h
+++ b/register_types.h
@@ -1,4 +1,11 @@
 /* register_types.h */
 
-void register_gdpdf_types();
-void unregister_gdpdf_types();
+#ifndef GDPDF_REGISTER_TYPES_H
+#define GDPDF_REGISTER_TYPES_H
+
+#include "modules/register_module_types.h"
+
+void initialize_gdpdf_module(ModuleInitializationLevel p_level);
+void uninitialize_gdpdf_module(ModuleInitializationLevel p_level);
+
+#endif // GDPDF_REGISTER_TYPES_H


### PR DESCRIPTION
This updates the module API to support Godot 4.0.
The changes follow the documentation from [Custom modules in C++](https://docs.godotengine.org/en/stable/contributing/development/core_and_modules/custom_modules_in_cpp.html).

Data structures have been moved from `core` to `core/templates`.

Close #6.